### PR TITLE
Unpause/Pause button enhancement

### DIFF
--- a/src/pages/PlayerDashboard.tsx
+++ b/src/pages/PlayerDashboard.tsx
@@ -360,8 +360,12 @@ const PlayerDashboard = () => {
       const totalAmount = grossAmount + brokerage;
 
       // Check trading rules
-      if (!gameSettings.trading_allowed || gameSettings.current_round === gameSettings.closing_bell_round) {
+      if (gameSettings.current_round === gameSettings.closing_bell_round) {
         throw new Error('🔔 Trading is disabled during the Closing Bell round');
+      }
+      
+      if (!gameSettings.trading_allowed) {
+        throw new Error('⏸️ Trading has been paused by the administrator');
       }
       
       if (tradeType === 'sell' && gameSettings.current_round < 3) {
@@ -467,6 +471,11 @@ const PlayerDashboard = () => {
                   🔔 Closing Bell
                 </Badge>
               )}
+              {!gameSettings.trading_allowed && gameSettings.current_round !== gameSettings.closing_bell_round && (
+                <Badge variant="outline" className="border-orange-500 text-orange-600">
+                  ⏸️ Trading Paused
+                </Badge>
+              )}
             </div>
           </div>
           <div className="flex gap-2">
@@ -534,13 +543,18 @@ const PlayerDashboard = () => {
                   🔔 Trading is disabled during the Closing Bell round. Final prices have been set.
                 </CardDescription>
               )}
+              {!gameSettings.trading_allowed && gameSettings.current_round !== gameSettings.closing_bell_round && (
+                <CardDescription className="text-orange-600 font-semibold">
+                  ⏸️ Trading has been paused by the administrator. Please wait for further instructions.
+                </CardDescription>
+              )}
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex gap-2">
                 <Button
                   variant={tradeType === 'buy' ? 'default' : 'outline'}
                   onClick={() => setTradeType('buy')}
-                  disabled={gameSettings.current_round === gameSettings.closing_bell_round}
+                  disabled={!gameSettings.trading_allowed || gameSettings.current_round === gameSettings.closing_bell_round}
                   className={`flex-1 ${
                     tradeType === 'buy' 
                       ? 'bg-green-600 hover:bg-green-700 text-white' 
@@ -557,7 +571,7 @@ const PlayerDashboard = () => {
                       ? 'bg-red-600 hover:bg-red-700 text-white' 
                       : 'border-red-600 text-red-600 hover:bg-red-50'
                   }`}
-                  disabled={gameSettings.current_round < 3 || gameSettings.current_round === gameSettings.closing_bell_round}
+                  disabled={!gameSettings.trading_allowed || gameSettings.current_round < 3 || gameSettings.current_round === gameSettings.closing_bell_round}
                 >
                   Sell
                 </Button>
@@ -574,10 +588,16 @@ const PlayerDashboard = () => {
                 <Select 
                   value={selectedStock} 
                   onValueChange={setSelectedStock}
-                  disabled={gameSettings.current_round === gameSettings.closing_bell_round}
+                  disabled={!gameSettings.trading_allowed || gameSettings.current_round === gameSettings.closing_bell_round}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder={gameSettings.current_round === gameSettings.closing_bell_round ? "Trading Disabled" : "Choose a stock"} />
+                    <SelectValue placeholder={
+                      !gameSettings.trading_allowed 
+                        ? "Trading Paused" 
+                        : gameSettings.current_round === gameSettings.closing_bell_round 
+                          ? "Trading Disabled" 
+                          : "Choose a stock"
+                    } />
                   </SelectTrigger>
                   <SelectContent>
                     {stocks
@@ -597,9 +617,15 @@ const PlayerDashboard = () => {
                   type="number"
                   value={quantity}
                   onChange={(e) => setQuantity(e.target.value)}
-                  placeholder={gameSettings.current_round === gameSettings.closing_bell_round ? "Trading Disabled" : "Enter quantity"}
+                  placeholder={
+                    !gameSettings.trading_allowed 
+                      ? "Trading Paused" 
+                      : gameSettings.current_round === gameSettings.closing_bell_round 
+                        ? "Trading Disabled" 
+                        : "Enter quantity"
+                  }
                   min="1"
-                  disabled={gameSettings.current_round === gameSettings.closing_bell_round}
+                  disabled={!gameSettings.trading_allowed || gameSettings.current_round === gameSettings.closing_bell_round}
                 />
               </div>
 
@@ -631,7 +657,7 @@ const PlayerDashboard = () => {
 
               <Button 
                 onClick={handleTrade} 
-                disabled={loading || !selectedStock || !quantity || gameSettings.current_round === gameSettings.closing_bell_round}
+                disabled={loading || !selectedStock || !quantity || !gameSettings.trading_allowed || gameSettings.current_round === gameSettings.closing_bell_round}
                 variant={tradeType === 'sell' ? 'destructive' : 'default'}
                 className={`w-full ${
                   tradeType === 'buy' 


### PR DESCRIPTION
This pull request introduces an admin-controlled trading pause/resume feature across the application, allowing administrators to temporarily stop or resume trading for all teams, except during the Closing Bell round. The changes ensure that both the admin and player dashboards reflect the current trading status, and all trading actions are disabled when paused.

**Admin Dashboard Enhancements:**

* Added a trading pause/resume toggle UI with clear status indicators and feedback, preventing resuming during the Closing Bell round. [[1]](diffhunk://#diff-98f986ea9dd26e1daffe61033941550361952911a310cf0ec18c704c29e261f7R481-R524) [[2]](diffhunk://#diff-98f986ea9dd26e1daffe61033941550361952911a310cf0ec18c704c29e261f7R797-R823)
* Updated imports to include new icons and components for the enhanced trading control UI.

**Player Dashboard Updates:**

* Trading actions (buy/sell, stock selection, quantity input, and trade button) are now disabled if trading is paused or during the Closing Bell round. [[1]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cR546-R557) [[2]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cL560-R574) [[3]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cL577-R600) [[4]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cL600-R628) [[5]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cL634-R660)
* Clear error messages and UI indicators are shown to players when trading is paused by the administrator or during the Closing Bell round. [[1]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cL363-R370) [[2]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cR474-R478) [[3]](diffhunk://#diff-0f194aef5dad106c10272c3a95daf72b73a0622c4c128cd8118ce29cbe04328cR546-R557)